### PR TITLE
Handle when user login session is inactive

### DIFF
--- a/mousetracks2/components/tracking.py
+++ b/mousetracks2/components/tracking.py
@@ -19,11 +19,13 @@ from ..config import GlobalConfig
 from ..constants import UPDATES_PER_SECOND, DEFAULT_PROFILE_NAME
 from ..context import CTX
 from ..exceptions import ExitRequest
+from ..types import RectList
 from ..utils import keycodes
 from ..utils.monitor import MonitorData
 from ..utils.input import get_cursor_pos
 from ..utils.interface import Interfaces
-from ..utils.system import MonitorEventListener, ControllerEventListener, ForegroundAppListener, hide_child_process
+from ..utils.system import (MonitorEventListener, ControllerEventListener, ForegroundAppListener,
+                             SessionActivityListener, hide_child_process)
 
 
 if XInput is None:
@@ -121,6 +123,7 @@ class Tracking(Component):
         self.autosave = True
         self.update_apps = True
         self.update_monitors = True
+        self.session_active = True
         self.data = DataState(0)
 
         self.config = GlobalConfig()
@@ -149,6 +152,21 @@ class Tracking(Component):
         self._application_listener = ForegroundAppListener()
         self._application_listener.start()
 
+        self._session_listener = SessionActivityListener()
+        self._session_listener.start()
+
+    def _set_profile(self, name: str, process_id: int | None, rects: RectList,
+                     force: bool = False) -> None:
+        """Switch to a new profile, flushing any pending activity first."""
+        if force or name != self.profile_name:
+            self.data.tick_modified = self.data.tick_current
+            self._calculate_inactivity()
+            self.data.pynput_opcodes.clear()
+            self.data.pynput_quick_press.clear()
+            self.profile_name = name
+
+        self.send_data(ipc.CurrentProfileChanged(name, process_id, rects))
+
     def _receive_data(self) -> None:
         for message in self.receive_data():
             match message:
@@ -169,16 +187,7 @@ class Tracking(Component):
                     raise RuntimeError('[Tracking] Test Exception')
 
                 case ipc.TrackedApplicationDetected():
-
-                    # Profile has changed, so reset the data
-                    if message.name != self.profile_name:
-                        self.data.tick_modified = self.data.tick_current
-                        self._calculate_inactivity()
-                        self.data.pynput_opcodes.clear()
-                        self.data.pynput_quick_press.clear()
-                        self.profile_name = message.name
-
-                    self.send_data(ipc.CurrentProfileChanged(message.name, message.process_id, message.rects))
+                    self._set_profile(message.name, message.process_id, message.rects)
 
                 case ipc.Autosave():
                     self.autosave = message.enabled
@@ -330,7 +339,7 @@ class Tracking(Component):
 
     def _pynput_mouse_click(self, x: int, y: int, button: pynput.mouse.Button, pressed: bool) -> None:
         """Triggers on mouse click."""
-        if self.state != ipc.TrackingState.Running:
+        if self.state != ipc.TrackingState.Running or not self.session_active:
             return
 
         with self._exception_handler():
@@ -351,7 +360,7 @@ class Tracking(Component):
         The scroll vector is mostly -1, 0 or 1, but support has been
         added in case it can go outside this range.
         """
-        if self.state != ipc.TrackingState.Running or not self.track_mouse:
+        if self.state != ipc.TrackingState.Running or not self.session_active or not self.track_mouse:
             return
 
         with self._exception_handler():
@@ -370,7 +379,7 @@ class Tracking(Component):
 
     def _pynput_key_press(self, key: pynput.keyboard.KeyCode | pynput.keyboard.Key | None) -> None:
         """Handle when a key is pressed."""
-        if self.state != ipc.TrackingState.Running or key is None:
+        if self.state != ipc.TrackingState.Running or not self.session_active or key is None:
             return
 
         with self._exception_handler():
@@ -393,7 +402,9 @@ class Tracking(Component):
                     self.data.pynput_quick_press.append(vk)
 
     def _key_press(self, keycode: int | keycodes.KeyCode, quick_press: bool = False) -> None:
-        """Handle key presses."""
+        """Handle key presses.
+        This intentionally has no guards against application state.
+        """
         self.data.tick_modified = self.data.tick_current
         press_start, press_latest = self.data.key_presses.get(keycode, (self.data.tick_current, 0))
         is_click = keycode in keycodes.CLICK_CODES
@@ -432,16 +443,31 @@ class Tracking(Component):
         for tick, data in self._run_with_state():
             self.send_data(ipc.Tick(tick, int(time.time())))
 
+            # Check if the user's login session is active
+            session_active = self._session_listener.triggered
+            if session_active != self.session_active:
+                self.session_active = session_active
+                # Force a recheck of data if active
+                if session_active:
+                    print('[Tracking] User session is active.')
+                    self.send_data(ipc.RequestRunningAppCheck())
+                    self._refresh_monitor_data()
+
+                # Force the default profile if inactive
+                else:
+                    print('[Tracking] User session is inactive.')
+                    self._set_profile(DEFAULT_PROFILE_NAME, None, RectList(), force=True)
+
             # Check for loaded applications
-            if self.update_apps and self._application_listener.triggered:
+            if self._application_listener.triggered and self.update_apps and session_active:
                 self.send_data(ipc.RequestRunningAppCheck())
 
             # Update monitor data
-            if self.update_monitors and self._monitor_listener.triggered:
+            if self._monitor_listener.triggered and self.update_monitors:
                 self._refresh_monitor_data()
 
             # Update mouse data
-            if self.track_mouse:
+            if self.track_mouse and session_active:
                 mouse_position = self._live_mouse_position
 
                 # Check if mouse position is inactive (such as a screensaver)
@@ -479,7 +505,7 @@ class Tracking(Component):
                         data.gamepads_previous = data.gamepads_current
 
                 for gamepad, active in enumerate(data.gamepads_current):
-                    if not active:
+                    if not active or not session_active:
                         continue
 
                     # Get a snapshot of the current gamepad state
@@ -522,7 +548,7 @@ class Tracking(Component):
                         data.gamepad_stick_r_position[gamepad] = stick_r
                         self.send_data(ipc.ThumbstickMove(gamepad, ipc.ThumbstickMove.Thumbstick.Right, stick_r))
 
-            if self.track_network and not tick % UPDATES_PER_SECOND:
+            if self.track_network and session_active and not tick % UPDATES_PER_SECOND:
                 for interface_name, counters in psutil.net_io_counters(pernic=True).items():
                     prev_sent = data.bytes_sent_previous.get(interface_name, 0)
                     prev_recv = data.bytes_recv_previous.get(interface_name, 0)
@@ -553,3 +579,4 @@ class Tracking(Component):
         self._pynput_mouse_listener.stop()
         self._pynput_keyboard_listener.stop()
         self._monitor_listener.stop()
+        self._session_listener.stop()

--- a/mousetracks2/components/tracking.py
+++ b/mousetracks2/components/tracking.py
@@ -548,7 +548,7 @@ class Tracking(Component):
                         data.gamepad_stick_r_position[gamepad] = stick_r
                         self.send_data(ipc.ThumbstickMove(gamepad, ipc.ThumbstickMove.Thumbstick.Right, stick_r))
 
-            if self.track_network and session_active and not tick % UPDATES_PER_SECOND:
+            if self.track_network and not tick % UPDATES_PER_SECOND:
                 for interface_name, counters in psutil.net_io_counters(pernic=True).items():
                     prev_sent = data.bytes_sent_previous.get(interface_name, 0)
                     prev_recv = data.bytes_recv_previous.get(interface_name, 0)

--- a/mousetracks2/utils/system/__init__.py
+++ b/mousetracks2/utils/system/__init__.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     ControllerEventListener: Type[base.EventListener]
     ForegroundAppListener: Type[base.EventListener]
     UserResizeAppListener: Type[base.EventListener]
+    SessionActivityListener: Type[base.EventListener]
 
 match sys.platform:
     case 'win32':
@@ -23,6 +24,7 @@ match sys.platform:
         from .windows import Window
         from .windows import MonitorEventListener, ControllerEventListener
         from .windows import ForegroundAppListener, UserResizeAppListener
+        from .windows import SessionActivityListener
         from .base import hide_child_process
         from .windows import prepare_application_icon
         from .windows import update_installer_version_number
@@ -36,6 +38,7 @@ match sys.platform:
         from .macos import Window
         from .base import MonitorEventListener, ControllerEventListener
         from .base import ForegroundAppListener, UserResizeAppListener
+        from .base import SessionActivityListener
         from .macos import hide_child_process, prepare_application_icon
         from .base import update_installer_version_number
         from .base import force_physical_dpi_awareness
@@ -48,6 +51,7 @@ match sys.platform:
         from .linux import Window
         from .base import MonitorEventListener, ControllerEventListener
         from .base import ForegroundAppListener, UserResizeAppListener
+        from .base import SessionActivityListener
         from .base import hide_child_process, prepare_application_icon
         from .base import update_installer_version_number
         from .base import force_physical_dpi_awareness
@@ -60,6 +64,7 @@ __all__ = [
     'Window',
     'MonitorEventListener', 'ControllerEventListener',
     'ForegroundAppListener', 'UserResizeAppListener',
+    'SessionActivityListener',
     'hide_child_process', 'prepare_application_icon',
     'update_installer_version_number',
     'force_physical_dpi_awareness',

--- a/mousetracks2/utils/system/base.py
+++ b/mousetracks2/utils/system/base.py
@@ -147,6 +147,14 @@ class UserResizeAppListener(EventListener):
         return False
 
 
+class SessionActivityListener(EventListener):
+    """Determine if the user session is currently active."""
+
+    @property
+    def triggered(self) -> bool:
+        return True
+
+
 def hide_child_process() -> None:
     """This is here to allow macOS to hide the child processes."""
 

--- a/mousetracks2/utils/system/windows.py
+++ b/mousetracks2/utils/system/windows.py
@@ -34,6 +34,8 @@ psapi = ctypes.windll.psapi
 
 shell32 = ctypes.windll.shell32
 
+wtsapi32 = ctypes.windll.wtsapi32
+
 SM_CXSCREEN = 0
 
 SM_CYSCREEN = 1
@@ -48,9 +50,13 @@ WM_DISPLAYCHANGE = 0x007E
 
 WM_DEVICECHANGE  = 0x0219
 
+WM_WTSSESSION_CHANGE = 0x02B1
+
 PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
 
 DBT_DEVNODES_CHANGED = 0x0007
+
+NOTIFY_FOR_THIS_SESSION = 0
 
 EVENT_SYSTEM_FOREGROUND = 0x0003
 
@@ -118,6 +124,16 @@ PROCESS_DPI_UNAWARE = 0
 PROCESS_SYSTEM_DPI_AWARE = 1
 PROCESS_PER_MONITOR_DPI_AWARE = 2
 
+# WM_WTSSESSION_CHANGE wparam values
+WTS_CONSOLE_CONNECT = 0x1
+WTS_CONSOLE_DISCONNECT = 0x2
+WTS_REMOTE_CONNECT = 0x3
+WTS_REMOTE_DISCONNECT = 0x4
+WTS_SESSION_LOGON = 0x5
+WTS_SESSION_LOGOFF = 0x6
+WTS_SESSION_LOCK = 0x7
+WTS_SESSION_UNLOCK = 0x8
+
 user32.GetWindowThreadProcessId.argtypes = [HWND, ctypes.POINTER(DWORD)]
 user32.GetWindowThreadProcessId.restype = DWORD
 
@@ -163,6 +179,12 @@ user32.DefWindowProcW.argtypes = [HWND, UINT, WPARAM, LPARAM]
 
 user32.SetThreadDpiAwarenessContext.argtypes = [ctypes.wintypes.HANDLE]
 user32.SetThreadDpiAwarenessContext.restype = ctypes.wintypes.HANDLE
+
+wtsapi32.WTSRegisterSessionNotification.argtypes = [HWND, DWORD]
+wtsapi32.WTSRegisterSessionNotification.restype = BOOL
+
+wtsapi32.WTSUnRegisterSessionNotification.argtypes = [HWND]
+wtsapi32.WTSUnRegisterSessionNotification.restype = BOOL
 
 class WNDCLASS(ctypes.Structure):
     _fields_ = [
@@ -498,6 +520,12 @@ class _WindowMessageListener(base.EventListener):
         """Determine if a specific event has been fired."""
         return False
 
+    def setup(self, hwnd: int) -> None:
+        """Run additional setup once the hidden window has been created."""
+
+    def teardown(self, hwnd: int) -> None:
+        """Run cleanup before the hidden window is destroyed."""
+
     def _win_proc(self, hwnd: int, msg: int, wparam: int, lparam: int) -> int:
         if self.check(hwnd, msg, wparam, lparam):
             self.trigger()
@@ -523,6 +551,7 @@ class _WindowMessageListener(base.EventListener):
         )
         if not self._hwnd:
             raise ctypes.WinError(ctypes.get_last_error())
+        self.setup(self._hwnd)
 
         self.trigger()
 
@@ -534,6 +563,7 @@ class _WindowMessageListener(base.EventListener):
     def stop(self) -> None:
         """Stops the message loop and cleans up the window."""
         if self._hwnd:
+            self.teardown(self._hwnd)
             user32.PostMessageW(self._hwnd, WM_QUIT, 0, 0)
 
 
@@ -599,6 +629,37 @@ class ControllerEventListener(_WindowMessageListener):
 
     def check(self, hwnd: int, msg: int, wparam: int, lparam: int) -> bool:
         return msg == WM_DEVICECHANGE and wparam == DBT_DEVNODES_CHANGED
+
+
+class SessionActivityListener(_WindowMessageListener):
+    """Determine if the user session is currently active."""
+
+    INACTIVE_EVENTS = (WTS_SESSION_LOCK, WTS_SESSION_LOGOFF,
+                       WTS_CONSOLE_DISCONNECT, WTS_REMOTE_DISCONNECT)
+    ACTIVE_EVENTS = (WTS_SESSION_UNLOCK, WTS_CONSOLE_CONNECT, WTS_REMOTE_CONNECT)
+
+    def __init__(self) -> None:
+        self._active = True
+        super().__init__()
+
+    def setup(self, hwnd: int) -> None:
+        wtsapi32.WTSRegisterSessionNotification(hwnd, NOTIFY_FOR_THIS_SESSION)
+
+    def teardown(self, hwnd: int) -> None:
+        wtsapi32.WTSUnRegisterSessionNotification(hwnd)
+
+    def check(self, hwnd: int, msg: int, wparam: int, lparam: int) -> bool:
+        if msg != WM_WTSSESSION_CHANGE:
+            return False
+        if wparam in self.INACTIVE_EVENTS:
+            self._active = False
+        elif wparam in self.ACTIVE_EVENTS:
+            self._active = True
+        return False
+
+    @property
+    def triggered(self) -> bool:
+        return self._active
 
 
 class ForegroundAppListener(_WinEventHookListener):


### PR DESCRIPTION
Certain things like gamepad presses would "leak" from other login sessions, but other things wouldn't. This ensures tracking gets disabled while the user session is not active.

Resolves #98.